### PR TITLE
Correcting bytes/string issues for python3

### DIFF
--- a/check_releases.py
+++ b/check_releases.py
@@ -64,7 +64,7 @@ def check_firmware():
             if ret.status_code != 200:
                 print("Missing firmware file", firmware)
                 ok = False
-                data = ''
+                data = b''
             else:
                 data = bytes(ret.text, 'utf-8')
 
@@ -72,7 +72,7 @@ def check_firmware():
             if not os.path.exists(firmware[len('/data/'):]):
                 print("Missing firmware file", firmware)
                 ok = False
-                data = ''
+                data = b''
             else:
                 data = open(firmware[len('/data/'):], 'r').read()
 


### PR DESCRIPTION
It still (correctly) exits 1, but at least it doesn't crash with cryptic python stack