### PR TITLE
chore(fw): upload recent bootloaders

### DIFF
--- a/bootloader/2/bootloader-2.1.16.bin
+++ b/bootloader/2/bootloader-2.1.16.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ffdbe7bb21af230d8577af763fe0b9ab12a65fc1c91a6356e87b9ce46336a90
+size 128512

--- a/bootloader/2/bootloader-2.1.8.bin
+++ b/bootloader/2/bootloader-2.1.8.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02b958ca5e4f6f5078523f002d9f55f6d3f9890be03edfec5ea105b4b16af8d2
+size 102912

--- a/bootloader/t2b1/bootloader-t2b1-2.1.16.bin
+++ b/bootloader/t2b1/bootloader-t2b1-2.1.16.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e2653bfb02cfaa62ec20ae9e4c57e84b7721517639c3eebc22fe3032649c11a5
+size 105984

--- a/bootloader/t2t1/bootloader-t2t1-2.1.16.bin
+++ b/bootloader/t2t1/bootloader-t2t1-2.1.16.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0ffdbe7bb21af230d8577af763fe0b9ab12a65fc1c91a6356e87b9ce46336a90
+size 128512

--- a/bootloader/t2t1/bootloader-t2t1-2.1.8.bin
+++ b/bootloader/t2t1/bootloader-t2t1-2.1.8.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:02b958ca5e4f6f5078523f002d9f55f6d3f9890be03edfec5ea105b4b16af8d2
+size 102912

--- a/bootloader/t3b1/bootloader-t3b1-2.1.16.bin
+++ b/bootloader/t3b1/bootloader-t3b1-2.1.16.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f9c9c323c4e0acca067f16bf9fe04dbf09672cbbd37ee2c3401c9f292e42287
+size 114688

--- a/bootloader/t3t1/bootloader-t3t1-2.1.16.bin
+++ b/bootloader/t3t1/bootloader-t3t1-2.1.16.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e276650572519ce1524858527270e95eafa9fbf75773604e5977b8d776c3fb8
+size 130048

--- a/bootloader/t3w1/bootloader-t3w1-2.1.16.bin
+++ b/bootloader/t3w1/bootloader-t3w1-2.1.16.bin
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c37138c667ad29e45b8ea7f51f09456405e6d29facb57030db77ea4d13ce325f
+size 262144


### PR DESCRIPTION
A user of model T didn't find the most recent bootloader to recover via SD card. See: https://satoshilabs.slack.com/archives/CL1D61PQF/p1774875244106919

Uploading bootloaders for other models for consistency.