### PR TITLE
Add `authenticity.json` for T3W1

### DIFF
--- a/firmware/t3w1/authenticity.json
+++ b/firmware/t3w1/authenticity.json
@@ -1,0 +1,4 @@
+{
+    "timestamp": "2026-07-20T12:00:00+00:00",
+    "revoked_pubkeys": []
+}


### PR DESCRIPTION
T3W1 uses a blacklist (list of revoked pubkeys) for device authenticity check. The list is empty so far. However, when the list is not available, it raises errors/warnings when authenticating using trezorctl. This minimal json provides trezorctl with empty revoked list, which is enough to resolve the trezorctl's issues.